### PR TITLE
이호전 개발자 과제입니다.

### DIFF
--- a/.github/workflows/flutter-android.yml
+++ b/.github/workflows/flutter-android.yml
@@ -1,0 +1,32 @@
+name: Flutter Android CI
+
+on:
+  push:
+    branches: [ "release" ]   # main 브랜치에 push 시 실행
+  pull_request:
+    branches: [ "release" ]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+
+      - name: Setup Flutter
+        uses: subosito/flutter-action@v2
+        with:
+          flutter-version: '3.35.2'   # 원하는 Flutter 버전 지정
+
+      - name: Install dependencies
+        run: flutter pub get
+
+      - name: Build Debug APK
+        run: flutter build apk --debug
+
+      - name: Upload Debug APK
+        uses: actions/upload-artifact@v3
+        with:
+          name: flutter-app-debug
+          path: build/app/outputs/flutter-apk/app-debug.apk

--- a/.github/workflows/flutter-android.yml
+++ b/.github/workflows/flutter-android.yml
@@ -11,13 +11,13 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - name: Checkout
+      - name: Checkout repository
         uses: actions/checkout@v3
 
       - name: Setup Flutter
         uses: subosito/flutter-action@v2
         with:
-          flutter-version: '3.35.2'   # 원하는 Flutter 버전 지정
+          flutter-version: '3.35.2'
 
       - name: Install dependencies
         run: flutter pub get
@@ -26,7 +26,7 @@ jobs:
         run: flutter build apk --debug
 
       - name: Upload Debug APK
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
-          name: flutter-app-debug
+          name: app-debug
           path: build/app/outputs/flutter-apk/app-debug.apk

--- a/android/gradle/wrapper/gradle-wrapper.properties
+++ b/android/gradle/wrapper/gradle-wrapper.properties
@@ -2,4 +2,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.3-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.7-all.zip

--- a/android/settings.gradle
+++ b/android/settings.gradle
@@ -18,8 +18,8 @@ pluginManagement {
 
 plugins {
     id "dev.flutter.flutter-plugin-loader" version "1.0.0"
-    id "com.android.application" version "8.1.0" apply false
-    id "org.jetbrains.kotlin.android" version "1.8.22" apply false
+    id "com.android.application" version "8.6.0" apply false
+    id "org.jetbrains.kotlin.android" version "2.1.0" apply false
 }
 
 include ":app"

--- a/lib/api/api_result.dart
+++ b/lib/api/api_result.dart
@@ -1,0 +1,18 @@
+abstract class ApiResult<T> {
+  ApiResult._();
+
+  factory ApiResult.success(T data) = Success<T>._;
+  factory ApiResult.error(String exception) = Failure<T>._;
+}
+
+class Success<T> extends ApiResult<T> {
+  Success._(this.data) : super._();
+
+  final T data;
+}
+
+class Failure<T> extends ApiResult<T> {
+  Failure._(this.exception) : super._();
+
+  final String exception;
+}

--- a/lib/api/models/requests/messages_request_model.dart
+++ b/lib/api/models/requests/messages_request_model.dart
@@ -1,0 +1,10 @@
+import 'package:json_annotation/json_annotation.dart';
+part 'messages_request_model.g.dart';
+
+@JsonSerializable()
+class MessagesRequestModel {
+  MessagesRequestModel();
+
+  factory MessagesRequestModel.fromJson(Map<String, dynamic> json) => _$MessagesRequestModelFromJson(json);
+  Map<String, dynamic> toJson() => _$MessagesRequestModelToJson(this);
+}

--- a/lib/api/models/requests/messages_request_model.g.dart
+++ b/lib/api/models/requests/messages_request_model.g.dart
@@ -1,0 +1,15 @@
+// GENERATED CODE - DO NOT MODIFY BY HAND
+
+part of 'messages_request_model.dart';
+
+// **************************************************************************
+// JsonSerializableGenerator
+// **************************************************************************
+
+MessagesRequestModel _$MessagesRequestModelFromJson(
+        Map<String, dynamic> json) =>
+    MessagesRequestModel();
+
+Map<String, dynamic> _$MessagesRequestModelToJson(
+        MessagesRequestModel instance) =>
+    <String, dynamic>{};

--- a/lib/api/models/requests/rooms_request_model.dart
+++ b/lib/api/models/requests/rooms_request_model.dart
@@ -1,0 +1,10 @@
+import 'package:json_annotation/json_annotation.dart';
+part 'rooms_request_model.g.dart';
+
+@JsonSerializable()
+class RoomsRequestModel {
+  RoomsRequestModel();
+
+factory RoomsRequestModel.fromJson(Map<String, dynamic> json) => _$RoomsRequestModelFromJson(json);
+Map<String, dynamic> toJson() => _$RoomsRequestModelToJson(this);
+}

--- a/lib/api/models/requests/rooms_request_model.g.dart
+++ b/lib/api/models/requests/rooms_request_model.g.dart
@@ -1,0 +1,13 @@
+// GENERATED CODE - DO NOT MODIFY BY HAND
+
+part of 'rooms_request_model.dart';
+
+// **************************************************************************
+// JsonSerializableGenerator
+// **************************************************************************
+
+RoomsRequestModel _$RoomsRequestModelFromJson(Map<String, dynamic> json) =>
+    RoomsRequestModel();
+
+Map<String, dynamic> _$RoomsRequestModelToJson(RoomsRequestModel instance) =>
+    <String, dynamic>{};

--- a/lib/api/models/requests/users_request_model.dart
+++ b/lib/api/models/requests/users_request_model.dart
@@ -1,0 +1,10 @@
+import 'package:json_annotation/json_annotation.dart';
+part 'users_request_model.g.dart';
+
+@JsonSerializable()
+class UsersRequestModel {
+  UsersRequestModel();
+
+factory UsersRequestModel.fromJson(Map<String, dynamic> json) => _$UsersRequestModelFromJson(json);
+Map<String, dynamic> toJson() => _$UsersRequestModelToJson(this);
+}

--- a/lib/api/models/requests/users_request_model.g.dart
+++ b/lib/api/models/requests/users_request_model.g.dart
@@ -1,0 +1,13 @@
+// GENERATED CODE - DO NOT MODIFY BY HAND
+
+part of 'users_request_model.dart';
+
+// **************************************************************************
+// JsonSerializableGenerator
+// **************************************************************************
+
+UsersRequestModel _$UsersRequestModelFromJson(Map<String, dynamic> json) =>
+    UsersRequestModel();
+
+Map<String, dynamic> _$UsersRequestModelToJson(UsersRequestModel instance) =>
+    <String, dynamic>{};

--- a/lib/api/models/responses/messages_response_model.dart
+++ b/lib/api/models/responses/messages_response_model.dart
@@ -1,0 +1,16 @@
+import 'package:json_annotation/json_annotation.dart';
+import 'package:mobile1_flutter_coding_test/models/message_model.dart';
+part 'messages_response_model.g.dart';
+
+@JsonSerializable()
+class MessagesResponseModel {
+  final List<MessageModel> messages;
+
+  MessagesResponseModel({
+    required this.messages,
+  });
+
+  factory MessagesResponseModel.fromJson(Map<String, dynamic> json) => _$MessagesResponseModelFromJson(json);
+
+  Map<String, dynamic> toJson() => _$MessagesResponseModelToJson(this);
+}

--- a/lib/api/models/responses/messages_response_model.g.dart
+++ b/lib/api/models/responses/messages_response_model.g.dart
@@ -1,0 +1,21 @@
+// GENERATED CODE - DO NOT MODIFY BY HAND
+
+part of 'messages_response_model.dart';
+
+// **************************************************************************
+// JsonSerializableGenerator
+// **************************************************************************
+
+MessagesResponseModel _$MessagesResponseModelFromJson(
+        Map<String, dynamic> json) =>
+    MessagesResponseModel(
+      messages: (json['messages'] as List<dynamic>)
+          .map((e) => MessageModel.fromJson(e as Map<String, dynamic>))
+          .toList(),
+    );
+
+Map<String, dynamic> _$MessagesResponseModelToJson(
+        MessagesResponseModel instance) =>
+    <String, dynamic>{
+      'messages': instance.messages,
+    };

--- a/lib/api/models/responses/response_model.dart
+++ b/lib/api/models/responses/response_model.dart
@@ -1,0 +1,13 @@
+import 'package:json_annotation/json_annotation.dart';
+
+part 'response_model.g.dart';
+
+@JsonSerializable()
+class ResponseModel {
+  int? r;
+  Map<String, dynamic>? d;
+
+  ResponseModel({this.r, this.d});
+
+  factory ResponseModel.fromJson(Map<String, dynamic> json) => _$ResponseModelFromJson(json);
+}

--- a/lib/api/models/responses/response_model.g.dart
+++ b/lib/api/models/responses/response_model.g.dart
@@ -1,0 +1,19 @@
+// GENERATED CODE - DO NOT MODIFY BY HAND
+
+part of 'response_model.dart';
+
+// **************************************************************************
+// JsonSerializableGenerator
+// **************************************************************************
+
+ResponseModel _$ResponseModelFromJson(Map<String, dynamic> json) =>
+    ResponseModel(
+      r: (json['r'] as num?)?.toInt(),
+      d: json['d'] as Map<String, dynamic>?,
+    );
+
+Map<String, dynamic> _$ResponseModelToJson(ResponseModel instance) =>
+    <String, dynamic>{
+      'r': instance.r,
+      'd': instance.d,
+    };

--- a/lib/api/models/responses/rooms_response_model.dart
+++ b/lib/api/models/responses/rooms_response_model.dart
@@ -1,0 +1,16 @@
+import 'package:json_annotation/json_annotation.dart';
+import 'package:mobile1_flutter_coding_test/models/room_model.dart';
+part 'rooms_response_model.g.dart';
+
+@JsonSerializable()
+class RoomsResponseModel {
+  final List<RoomModel> chatRooms;
+
+  RoomsResponseModel({
+    required this.chatRooms,
+  });
+
+  factory RoomsResponseModel.fromJson(Map<String, dynamic> json) => _$RoomsResponseModelFromJson(json);
+
+  Map<String, dynamic> toJson() => _$RoomsResponseModelToJson(this);
+}

--- a/lib/api/models/responses/rooms_response_model.g.dart
+++ b/lib/api/models/responses/rooms_response_model.g.dart
@@ -1,0 +1,19 @@
+// GENERATED CODE - DO NOT MODIFY BY HAND
+
+part of 'rooms_response_model.dart';
+
+// **************************************************************************
+// JsonSerializableGenerator
+// **************************************************************************
+
+RoomsResponseModel _$RoomsResponseModelFromJson(Map<String, dynamic> json) =>
+    RoomsResponseModel(
+      chatRooms: (json['chatRooms'] as List<dynamic>)
+          .map((e) => RoomModel.fromJson(e as Map<String, dynamic>))
+          .toList(),
+    );
+
+Map<String, dynamic> _$RoomsResponseModelToJson(RoomsResponseModel instance) =>
+    <String, dynamic>{
+      'chatRooms': instance.chatRooms,
+    };

--- a/lib/api/models/responses/users_response_model.dart
+++ b/lib/api/models/responses/users_response_model.dart
@@ -1,0 +1,16 @@
+import 'package:json_annotation/json_annotation.dart';
+import 'package:mobile1_flutter_coding_test/models/user_model.dart';
+part 'users_response_model.g.dart';
+
+@JsonSerializable()
+class UsersResponseModel {
+  final List<UserModel> users;
+
+  UsersResponseModel({
+    required this.users,
+  });
+
+  factory UsersResponseModel.fromJson(Map<String, dynamic> json) => _$UsersResponseModelFromJson(json);
+
+  Map<String, dynamic> toJson() => _$UsersResponseModelToJson(this);
+}

--- a/lib/api/models/responses/users_response_model.g.dart
+++ b/lib/api/models/responses/users_response_model.g.dart
@@ -1,0 +1,19 @@
+// GENERATED CODE - DO NOT MODIFY BY HAND
+
+part of 'users_response_model.dart';
+
+// **************************************************************************
+// JsonSerializableGenerator
+// **************************************************************************
+
+UsersResponseModel _$UsersResponseModelFromJson(Map<String, dynamic> json) =>
+    UsersResponseModel(
+      users: (json['users'] as List<dynamic>)
+          .map((e) => UserModel.fromJson(e as Map<String, dynamic>))
+          .toList(),
+    );
+
+Map<String, dynamic> _$UsersResponseModelToJson(UsersResponseModel instance) =>
+    <String, dynamic>{
+      'users': instance.users,
+    };

--- a/lib/api/server_api.dart
+++ b/lib/api/server_api.dart
@@ -1,0 +1,28 @@
+
+import 'package:dio/dio.dart';
+import 'package:mobile1_flutter_coding_test/api/models/requests/messages_request_model.dart';
+import 'package:mobile1_flutter_coding_test/api/models/requests/rooms_request_model.dart';
+import 'package:mobile1_flutter_coding_test/api/models/requests/users_request_model.dart';
+import 'package:mobile1_flutter_coding_test/api/models/responses/messages_response_model.dart';
+import 'package:mobile1_flutter_coding_test/api/models/responses/response_model.dart';
+import 'package:mobile1_flutter_coding_test/api/models/responses/rooms_response_model.dart';
+import 'package:mobile1_flutter_coding_test/api/models/responses/users_response_model.dart';
+import 'package:mobile1_flutter_coding_test/commons/constants.dart';
+import 'package:retrofit/retrofit.dart';
+
+part 'server_api.g.dart';
+
+@RestApi(baseUrl: Constants.serverApiBaseUrl)
+abstract class ServerApi {
+  factory ServerApi(Dio dio, {String? baseUrl}) = _ServerApi;
+  
+  @GET(Constants.serverMessagesJsonUrl)
+  Future<String> getMessages(@Body() MessagesRequestModel body);
+
+  @GET(Constants.serverRoomsJsonUrl)
+  Future<String> getRooms(@Body() RoomsRequestModel body);
+
+  @GET(Constants.serverUsersJsonUrl)
+  Future<String> getUsers(@Body() UsersRequestModel body);
+
+}

--- a/lib/api/server_api.g.dart
+++ b/lib/api/server_api.g.dart
@@ -1,0 +1,133 @@
+// GENERATED CODE - DO NOT MODIFY BY HAND
+
+part of 'server_api.dart';
+
+// **************************************************************************
+// RetrofitGenerator
+// **************************************************************************
+
+// ignore_for_file: unnecessary_brace_in_string_interps,no_leading_underscores_for_local_identifiers,unused_element,unnecessary_string_interpolations,unused_element_parameter
+
+class _ServerApi implements ServerApi {
+  _ServerApi(this._dio, {this.baseUrl, this.errorLogger}) {
+    baseUrl ??=
+        'https://raw.githubusercontent.com/rsupportrnd/mobile1-flutter-coding-test/refs/heads/main/api';
+  }
+
+  final Dio _dio;
+
+  String? baseUrl;
+
+  final ParseErrorLogger? errorLogger;
+
+  @override
+  Future<String> getMessages(MessagesRequestModel body) async {
+    final _extra = <String, dynamic>{};
+    final queryParameters = <String, dynamic>{};
+    final _headers = <String, dynamic>{};
+    final _data = <String, dynamic>{};
+    _data.addAll(body.toJson());
+    final _options = _setStreamType<String>(
+      Options(method: 'GET', headers: _headers, extra: _extra)
+          .compose(
+            _dio.options,
+            '/messages.json',
+            queryParameters: queryParameters,
+            data: _data,
+          )
+          .copyWith(baseUrl: _combineBaseUrls(_dio.options.baseUrl, baseUrl)),
+    );
+    final _result = await _dio.fetch<String>(_options);
+    late String _value;
+    try {
+      _value = _result.data!;
+    } on Object catch (e, s) {
+      errorLogger?.logError(e, s, _options);
+      rethrow;
+    }
+    return _value;
+  }
+
+  @override
+  Future<String> getRooms(RoomsRequestModel body) async {
+    final _extra = <String, dynamic>{};
+    final queryParameters = <String, dynamic>{};
+    final _headers = <String, dynamic>{};
+    final _data = <String, dynamic>{};
+    _data.addAll(body.toJson());
+    final _options = _setStreamType<String>(
+      Options(method: 'GET', headers: _headers, extra: _extra)
+          .compose(
+            _dio.options,
+            '/rooms.json',
+            queryParameters: queryParameters,
+            data: _data,
+          )
+          .copyWith(baseUrl: _combineBaseUrls(_dio.options.baseUrl, baseUrl)),
+    );
+    final _result = await _dio.fetch<String>(_options);
+    late String _value;
+    try {
+      _value = _result.data!;
+    } on Object catch (e, s) {
+      errorLogger?.logError(e, s, _options);
+      rethrow;
+    }
+    return _value;
+  }
+
+  @override
+  Future<String> getUsers(UsersRequestModel body) async {
+    final _extra = <String, dynamic>{};
+    final queryParameters = <String, dynamic>{};
+    final _headers = <String, dynamic>{};
+    final _data = <String, dynamic>{};
+    _data.addAll(body.toJson());
+    final _options = _setStreamType<String>(
+      Options(method: 'GET', headers: _headers, extra: _extra)
+          .compose(
+            _dio.options,
+            '/users.json',
+            queryParameters: queryParameters,
+            data: _data,
+          )
+          .copyWith(baseUrl: _combineBaseUrls(_dio.options.baseUrl, baseUrl)),
+    );
+    final _result = await _dio.fetch<String>(_options);
+    late String _value;
+    try {
+      _value = _result.data!;
+    } on Object catch (e, s) {
+      errorLogger?.logError(e, s, _options);
+      rethrow;
+    }
+    return _value;
+  }
+
+  RequestOptions _setStreamType<T>(RequestOptions requestOptions) {
+    if (T != dynamic &&
+        !(requestOptions.responseType == ResponseType.bytes ||
+            requestOptions.responseType == ResponseType.stream)) {
+      if (T == String) {
+        requestOptions.responseType = ResponseType.plain;
+      } else {
+        requestOptions.responseType = ResponseType.json;
+      }
+    }
+    return requestOptions;
+  }
+
+  String _combineBaseUrls(String dioBaseUrl, String? baseUrl) {
+    if (baseUrl == null || baseUrl.trim().isEmpty) {
+      return dioBaseUrl;
+    }
+
+    final url = Uri.parse(baseUrl);
+
+    if (url.isAbsolute) {
+      return url.toString();
+    }
+
+    return Uri.parse(dioBaseUrl).resolveUri(url).toString();
+  }
+}

--- a/lib/commons/constants.dart
+++ b/lib/commons/constants.dart
@@ -1,0 +1,14 @@
+class Constants {
+  static const serverApiBaseUrl = 'https://raw.githubusercontent.com/rsupportrnd/mobile1-flutter-coding-test/refs/heads/main/api';
+  static const localMode = false;
+
+  static const serverMessagesJsonUrl = '/messages.json';
+  static const serverRoomsJsonUrl = '/rooms.json';
+  static const serverUsersJsonUrl = '/users.json';
+
+  static const localMessagesJsonPath = 'api/messages.json';
+  static const localRoomsJsonPath = 'api/rooms.json';
+  static const localUsersJsonPath = 'api/users.json';
+
+  static const dbPath = 'database.db';
+}

--- a/lib/commons/enums.dart
+++ b/lib/commons/enums.dart
@@ -1,0 +1,36 @@
+enum UserStatus {
+  unknown('unknown'),
+  offline('offline'),
+  online('online'),
+  doNotDisturb('do_not_disturb'),
+  away('away');
+
+  final String value;
+
+  const UserStatus(this.value);
+
+  static UserStatus fromString(String value) {
+    return UserStatus.values.firstWhere(
+          (e) => e.value == value,
+      orElse: () => UserStatus.unknown,
+    );
+  }
+}
+
+
+enum UserRole {
+  unknown('unknown'),
+  member('member'),
+  admin('admin');
+
+  final String value;
+
+  const UserRole(this.value);
+
+  static UserRole fromString(String value) {
+    return UserRole.values.firstWhere(
+          (e) => e.value == value,
+      orElse: () => UserRole.unknown,
+    );
+  }
+}

--- a/lib/commons/main_module.dart
+++ b/lib/commons/main_module.dart
@@ -1,0 +1,152 @@
+import 'dart:convert';
+
+import 'package:flutter/foundation.dart';
+import 'package:flutter/material.dart';
+import 'package:get/get.dart';
+import 'package:mobile1_flutter_coding_test/api/api_result.dart';
+import 'package:mobile1_flutter_coding_test/api/models/requests/messages_request_model.dart';
+import 'package:mobile1_flutter_coding_test/api/models/requests/rooms_request_model.dart';
+import 'package:mobile1_flutter_coding_test/api/models/requests/users_request_model.dart';
+import 'package:mobile1_flutter_coding_test/api/models/responses/messages_response_model.dart';
+import 'package:mobile1_flutter_coding_test/api/models/responses/rooms_response_model.dart';
+import 'package:mobile1_flutter_coding_test/api/models/responses/users_response_model.dart';
+import 'package:mobile1_flutter_coding_test/commons/constants.dart';
+import 'package:mobile1_flutter_coding_test/models/message_model.dart';
+import 'package:mobile1_flutter_coding_test/models/room_model.dart';
+import 'package:mobile1_flutter_coding_test/models/user_model.dart';
+import 'package:mobile1_flutter_coding_test/repositories/api_repository.dart';
+import 'package:mobile1_flutter_coding_test/repositories/db_repository.dart';
+import 'package:mobile1_flutter_coding_test/repositories/storage_repository.dart';
+
+class MainModule {
+  static final MainModule? _instance = MainModule();
+  static MainModule get instance {
+    return _instance!;
+  }
+
+  final StorageRepository _storageRepository = StorageRepository();
+  StorageRepository get storageRepository => _storageRepository;
+  final DbRepository _dbRepository = DbRepository();
+  DbRepository get dbRepository => _dbRepository;
+  final ApiRepository _apiRepository = ApiRepository(localMode: Constants.localMode);
+  ApiRepository get apiRepository => _apiRepository;
+
+  final RxList<MessageModel> messagesList = <MessageModel>[].obs;
+  final RxList<RoomModel> roomsList = <RoomModel>[].obs;
+  final RxList<UserModel> usersList = <UserModel>[].obs;
+
+  late UserModel _testUser;
+  UserModel get currentUser => _testUser;
+
+  Future<void> init() async {
+
+
+    await _storageRepository.init();
+    await _dbRepository.open(Constants.dbPath);
+
+    await _getDataFromApi();
+    await _registerTestUser();
+    await _getDataFromDb();
+  }
+
+  Future<void> _getDataFromApi() async {
+    // 서버 통신 후 DB에 저장
+    // 현재는 고정 JSON값 수신이지만, 매 실행시마다 수신 결과가 다른 상황을 가정하여
+    // 앱 실행시 항상 통신하고 DB에 저장한다.
+    var messagesApiResult = await _apiRepository.getMessages(MessagesRequestModel());
+    if (messagesApiResult is Success<MessagesResponseModel?>) {
+      for (var messages in messagesApiResult.data!.messages) {
+        await _dbRepository.insertMessage(messages);
+      }
+    }
+
+    var roomsApiResult = await _apiRepository.getRooms(RoomsRequestModel());
+    if (roomsApiResult is Success<RoomsResponseModel?>) {
+      for (var room in roomsApiResult.data!.chatRooms) {
+        await _dbRepository.insertRoom(room);
+      }
+    }
+
+    var userApiResult = await _apiRepository.getUsers(UsersRequestModel());
+    if (userApiResult is Success<UsersResponseModel?>) {
+      for (var user in userApiResult.data!.users) {
+        await _dbRepository.insertUser(user);
+      }
+    }
+  }
+
+  Future<void> _getDataFromDb() async {
+    // DB에 저장한 값을 불러오기
+    var messages = await _dbRepository.fetchMessagesAll();
+    if (messages != null ) {
+      // for (var message in messages) {
+      //   messagesList.add(message);
+      // }
+      messagesList.addAll(messages);
+    }
+
+    //
+    var rooms = await _dbRepository.fetchRoomsAll();
+    if (rooms != null ) {
+      roomsList.addAll(rooms);
+    }
+
+    var users = await _dbRepository.fetchUsersAll();
+
+    if (users != null ) {
+
+      final topUser = users.where((element) => element.userId == currentUser.userId).toList();
+      final others = users.where((element) => element.userId != currentUser.userId).toList();
+      users = [...topUser, ...others];
+
+      // for (var user in users) {
+      //   usersList.add(user);
+      // }
+      usersList.addAll(users);
+    }
+
+  }
+
+  Future<void> _registerTestUser() async {
+    String userJson = "{\"userId\": \"user99\", \"name\": \"H. J. Lee\", \"email\": \"kz0327r@gmail.com\", \"profilePicture\": \"https://storage.googleapis.com/cms-storage-bucket/icon_flutter.0dbfcc7a59cd1cf16282.png\", \"status\": \"online\", \"role\": \"member\"}";
+    var decodedJson = jsonDecode(userJson);
+    _testUser = UserModel.fromJson(decodedJson);
+
+    await _dbRepository.insertUser(currentUser);
+  }
+
+  /// 한개 메시지만 전송(저장)하기
+  /// 서버 통신하는 상황을 가정하여 메서드 제작
+  Future<bool> sendMessage (MessageModel model ) async {
+    try {
+      await _dbRepository.insertMessage(model);
+      messagesList.add(model);
+      var lastMessage = LastMessageModel( sender: currentUser.userId,
+        content: model.content,
+        timestamp: DateTime.now().toUtc());
+        await _dbRepository.insertLastMessage(model.roomId,
+          lastMessage, replace:true);
+
+      var room = roomsList.firstWhere((r) => r.roomId == model.roomId);
+      var updatedRoom = RoomModel(
+        roomId: room.roomId,
+        roomName: room.roomName,
+        creator: room.creator,
+        participants: room.participants,
+        createdAt: room.createdAt,
+        lastMessage: lastMessage,
+        thumbnailImage: room.thumbnailImage
+      );
+
+      var index = roomsList.indexOf(room);
+      roomsList[index] = updatedRoom;
+      roomsList.sort ( (a, b) => b.lastMessage.timestamp.compareTo(a.lastMessage.timestamp));
+      roomsList.refresh();
+
+    } catch ( e ) {
+      debugPrint (e.toString());
+      return false;
+    }
+    return true;
+  }
+}

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -1,6 +1,14 @@
+import 'dart:convert';
+
 import 'package:flutter/material.dart';
+import 'package:get/get.dart';
+import 'package:mobile1_flutter_coding_test/commons/main_module.dart';
+import 'package:mobile1_flutter_coding_test/views/base_page_view.dart';
 
 void main() {
+
+  MainModule.instance.init();
+
   runApp(const MyApp());
 }
 
@@ -10,116 +18,39 @@ class MyApp extends StatelessWidget {
   // This widget is the root of your application.
   @override
   Widget build(BuildContext context) {
-    return MaterialApp(
-      title: 'Flutter Demo',
+    return GetMaterialApp(
+      // title: '회의실 앱',
       theme: ThemeData(
-        // This is the theme of your application.
-        //
-        // TRY THIS: Try running your application with "flutter run". You'll see
-        // the application has a purple toolbar. Then, without quitting the app,
-        // try changing the seedColor in the colorScheme below to Colors.green
-        // and then invoke "hot reload" (save your changes or press the "hot
-        // reload" button in a Flutter-supported IDE, or press "r" if you used
-        // the command line to start the app).
-        //
-        // Notice that the counter didn't reset back to zero; the application
-        // state is not lost during the reload. To reset the state, use hot
-        // restart instead.
-        //
-        // This works for code too, not just values: Most code changes can be
-        // tested with just a hot reload.
         colorScheme: ColorScheme.fromSeed(seedColor: Colors.deepPurple),
         useMaterial3: true,
       ),
-      home: const MyHomePage(title: 'Flutter Demo Home Page'),
+      home: const Home()
     );
   }
 }
 
-class MyHomePage extends StatefulWidget {
-  const MyHomePage({super.key, required this.title});
-
-  // This widget is the home page of your application. It is stateful, meaning
-  // that it has a State object (defined below) that contains fields that affect
-  // how it looks.
-
-  // This class is the configuration for the state. It holds the values (in this
-  // case the title) provided by the parent (in this case the App widget) and
-  // used by the build method of the State. Fields in a Widget subclass are
-  // always marked "final".
-
-  final String title;
+class Home extends StatefulWidget {
+  const Home({super.key});
 
   @override
-  State<MyHomePage> createState() => _MyHomePageState();
+  _HomeState createState() => _HomeState();
 }
 
-class _MyHomePageState extends State<MyHomePage> {
-  int _counter = 0;
+class _HomeState extends State<Home> with WidgetsBindingObserver {
+  @override
+  void initState() {
+    WidgetsBinding.instance.addObserver(this);
+    super.initState();
+  }
 
-  void _incrementCounter() {
-    setState(() {
-      // This call to setState tells the Flutter framework that something has
-      // changed in this State, which causes it to rerun the build method below
-      // so that the display can reflect the updated values. If we changed
-      // _counter without calling setState(), then the build method would not be
-      // called again, and so nothing would appear to happen.
-      _counter++;
-    });
+  @override
+  void dispose() {
+    WidgetsBinding.instance.removeObserver(this);
+    super.dispose();
   }
 
   @override
   Widget build(BuildContext context) {
-    // This method is rerun every time setState is called, for instance as done
-    // by the _incrementCounter method above.
-    //
-    // The Flutter framework has been optimized to make rerunning build methods
-    // fast, so that you can just rebuild anything that needs updating rather
-    // than having to individually change instances of widgets.
-    return Scaffold(
-      appBar: AppBar(
-        // TRY THIS: Try changing the color here to a specific color (to
-        // Colors.amber, perhaps?) and trigger a hot reload to see the AppBar
-        // change color while the other colors stay the same.
-        backgroundColor: Theme.of(context).colorScheme.inversePrimary,
-        // Here we take the value from the MyHomePage object that was created by
-        // the App.build method, and use it to set our appbar title.
-        title: Text(widget.title),
-      ),
-      body: Center(
-        // Center is a layout widget. It takes a single child and positions it
-        // in the middle of the parent.
-        child: Column(
-          // Column is also a layout widget. It takes a list of children and
-          // arranges them vertically. By default, it sizes itself to fit its
-          // children horizontally, and tries to be as tall as its parent.
-          //
-          // Column has various properties to control how it sizes itself and
-          // how it positions its children. Here we use mainAxisAlignment to
-          // center the children vertically; the main axis here is the vertical
-          // axis because Columns are vertical (the cross axis would be
-          // horizontal).
-          //
-          // TRY THIS: Invoke "debug painting" (choose the "Toggle Debug Paint"
-          // action in the IDE, or press "p" in the console), to see the
-          // wireframe for each widget.
-          mainAxisAlignment: MainAxisAlignment.center,
-          children: <Widget>[
-            const Text(
-              'You have pushed the button this many times:',
-            ),
-            Text(
-              '$_counter',
-              style: Theme.of(context).textTheme.headlineMedium,
-            ),
-          ],
-        ),
-      ),
-      floatingActionButton: FloatingActionButton(
-        onPressed: _incrementCounter,
-        tooltip: 'Increment',
-        child: const Icon(Icons.add),
-      ), // This trailing comma makes auto-formatting nicer for build methods.
-    );
+    return const BasePageView();
   }
 }

--- a/lib/models/message_model.dart
+++ b/lib/models/message_model.dart
@@ -1,0 +1,26 @@
+import 'package:json_annotation/json_annotation.dart';
+import 'package:mobile1_flutter_coding_test/utils/utils.dart';
+part 'message_model.g.dart';
+
+@JsonSerializable()
+class MessageModel {
+
+  final String roomId;
+  final String messageId;
+  final String sender;
+  final String content;
+  @JsonKey(fromJson: dateTimeFromTimestamp, toJson: timestampToInt)
+  final DateTime timestamp;
+
+  MessageModel({
+    required this.roomId,
+    required this.messageId,
+    required this.sender,
+    required this.content,
+    required this.timestamp,
+  });
+
+  factory MessageModel.fromJson(Map<String, dynamic> json) => _$MessageModelFromJson(json);
+
+  Map<String, dynamic> toJson() => _$MessageModelToJson(this);
+}

--- a/lib/models/message_model.g.dart
+++ b/lib/models/message_model.g.dart
@@ -1,0 +1,24 @@
+// GENERATED CODE - DO NOT MODIFY BY HAND
+
+part of 'message_model.dart';
+
+// **************************************************************************
+// JsonSerializableGenerator
+// **************************************************************************
+
+MessageModel _$MessageModelFromJson(Map<String, dynamic> json) => MessageModel(
+      roomId: json['roomId'] as String,
+      messageId: json['messageId'] as String,
+      sender: json['sender'] as String,
+      content: json['content'] as String,
+      timestamp: dateTimeFromTimestamp(json['timestamp']),
+    );
+
+Map<String, dynamic> _$MessageModelToJson(MessageModel instance) =>
+    <String, dynamic>{
+      'roomId': instance.roomId,
+      'messageId': instance.messageId,
+      'sender': instance.sender,
+      'content': instance.content,
+      'timestamp': timestampToInt(instance.timestamp),
+    };

--- a/lib/models/room_model.dart
+++ b/lib/models/room_model.dart
@@ -1,0 +1,47 @@
+import 'package:json_annotation/json_annotation.dart';
+import 'package:mobile1_flutter_coding_test/utils/utils.dart';
+
+part 'room_model.g.dart';
+
+@JsonSerializable()
+class RoomModel {
+  final String roomId;
+  final String roomName;
+  final String creator;
+  final List<String> participants;
+  @JsonKey(fromJson: dateTimeFromTimestamp, toJson: timestampToInt)
+  final DateTime createdAt;
+  final LastMessageModel lastMessage;
+  final String? thumbnailImage;
+
+  RoomModel({
+    required this.roomId,
+    required this.roomName,
+    required this.creator,
+    required this.participants,
+    required this.createdAt,
+    required this.lastMessage,
+    this.thumbnailImage,
+  });
+
+  factory RoomModel.fromJson(Map<String, dynamic> json) =>
+      _$RoomModelFromJson(json);
+  Map<String, dynamic> toJson() => _$RoomModelToJson(this);
+}
+
+@JsonSerializable()
+class LastMessageModel {
+  final String sender;
+  final String content;
+  @JsonKey(fromJson: dateTimeFromTimestamp, toJson: timestampToInt)
+  final DateTime timestamp;
+
+  LastMessageModel({
+    required this.sender,
+    required this.content,
+    required this.timestamp
+  });
+
+  factory LastMessageModel.fromJson(Map<String, dynamic> json) => _$LastMessageModelFromJson(json);
+  Map<String, dynamic> toJson() => _$LastMessageModelToJson(this);
+}

--- a/lib/models/room_model.g.dart
+++ b/lib/models/room_model.g.dart
@@ -1,0 +1,44 @@
+// GENERATED CODE - DO NOT MODIFY BY HAND
+
+part of 'room_model.dart';
+
+// **************************************************************************
+// JsonSerializableGenerator
+// **************************************************************************
+
+RoomModel _$RoomModelFromJson(Map<String, dynamic> json) => RoomModel(
+      roomId: json['roomId'] as String,
+      roomName: json['roomName'] as String,
+      creator: json['creator'] as String,
+      participants: (json['participants'] as List<dynamic>)
+          .map((e) => e as String)
+          .toList(),
+      createdAt: dateTimeFromTimestamp(json['createdAt']),
+      lastMessage: LastMessageModel.fromJson(
+          json['lastMessage'] as Map<String, dynamic>),
+      thumbnailImage: json['thumbnailImage'] as String?,
+    );
+
+Map<String, dynamic> _$RoomModelToJson(RoomModel instance) => <String, dynamic>{
+      'roomId': instance.roomId,
+      'roomName': instance.roomName,
+      'creator': instance.creator,
+      'participants': instance.participants,
+      'createdAt': timestampToInt(instance.createdAt),
+      'lastMessage': instance.lastMessage,
+      'thumbnailImage': instance.thumbnailImage,
+    };
+
+LastMessageModel _$LastMessageModelFromJson(Map<String, dynamic> json) =>
+    LastMessageModel(
+      sender: json['sender'] as String,
+      content: json['content'] as String,
+      timestamp: dateTimeFromTimestamp(json['timestamp']),
+    );
+
+Map<String, dynamic> _$LastMessageModelToJson(LastMessageModel instance) =>
+    <String, dynamic>{
+      'sender': instance.sender,
+      'content': instance.content,
+      'timestamp': timestampToInt(instance.timestamp),
+    };

--- a/lib/models/user_model.dart
+++ b/lib/models/user_model.dart
@@ -1,0 +1,30 @@
+import 'package:json_annotation/json_annotation.dart';
+import 'package:mobile1_flutter_coding_test/commons/enums.dart';
+import 'package:mobile1_flutter_coding_test/utils/utils.dart';
+part 'user_model.g.dart';
+
+@JsonSerializable()
+class UserModel {
+
+  final String userId;
+  final String name;
+  final String email;
+  final String? profilePicture;
+  @JsonKey(fromJson: userStatusFromValue, toJson: userStatusToString)
+  final UserStatus status;
+  @JsonKey(fromJson: userRoleFromValue, toJson: userRoleToString)
+  final UserRole role;
+
+  UserModel({
+    required this.userId,
+    required this.name,
+    required this.email,
+    this.profilePicture,
+    required this.status,
+    required this.role,
+  });
+
+  factory UserModel.fromJson(Map<String, dynamic> json) => _$UserModelFromJson(json);
+
+  Map<String, dynamic> toJson() => _$UserModelToJson(this);
+}

--- a/lib/models/user_model.g.dart
+++ b/lib/models/user_model.g.dart
@@ -1,0 +1,25 @@
+// GENERATED CODE - DO NOT MODIFY BY HAND
+
+part of 'user_model.dart';
+
+// **************************************************************************
+// JsonSerializableGenerator
+// **************************************************************************
+
+UserModel _$UserModelFromJson(Map<String, dynamic> json) => UserModel(
+      userId: json['userId'] as String,
+      name: json['name'] as String,
+      email: json['email'] as String,
+      profilePicture: json['profilePicture'] as String?,
+      status: userStatusFromValue(json['status']),
+      role: userRoleFromValue(json['role']),
+    );
+
+Map<String, dynamic> _$UserModelToJson(UserModel instance) => <String, dynamic>{
+      'userId': instance.userId,
+      'name': instance.name,
+      'email': instance.email,
+      'profilePicture': instance.profilePicture,
+      'status': userStatusToString(instance.status),
+      'role': userRoleToString(instance.role),
+    };

--- a/lib/repositories/api_repository.dart
+++ b/lib/repositories/api_repository.dart
@@ -1,0 +1,83 @@
+import 'dart:convert';
+
+import 'package:dio/dio.dart';
+import 'package:flutter/foundation.dart';
+import 'package:flutter/services.dart';
+import 'package:mobile1_flutter_coding_test/api/api_result.dart';
+import 'package:mobile1_flutter_coding_test/api/models/requests/messages_request_model.dart';
+import 'package:mobile1_flutter_coding_test/api/models/requests/rooms_request_model.dart';
+import 'package:mobile1_flutter_coding_test/api/models/requests/users_request_model.dart';
+import 'package:mobile1_flutter_coding_test/api/models/responses/messages_response_model.dart';
+import 'package:mobile1_flutter_coding_test/api/models/responses/rooms_response_model.dart';
+import 'package:mobile1_flutter_coding_test/api/models/responses/users_response_model.dart';
+import 'package:mobile1_flutter_coding_test/api/server_api.dart';
+import 'package:mobile1_flutter_coding_test/commons/constants.dart';
+
+final Dio _dio = Dio(BaseOptions(headers: {}));
+
+class ApiRepository {
+
+  final ServerApi serverApi = ServerApi(_dio);
+  ApiRepository({required this.localMode});
+  final bool localMode;
+
+  ApiResult<T?> handleResponse<T>(T? data, Exception? exception) {
+
+    if ( data == null ) {
+      String exceptionMessage = exception.toString();
+      debugPrint (exceptionMessage);
+      return ApiResult.error(exceptionMessage);
+    }
+
+    return ApiResult.success(data);
+  }
+
+  /// 각 원격 JSON 파일 호출 시 파라미터를 전달하는 부분은 없지만,
+  /// REST API를 호출하는 상황을 가정하여 각각의 RequestModel을 정의하였음.
+
+  /// 메시지 목록 호출
+  Future<ApiResult<MessagesResponseModel?>> getMessages(MessagesRequestModel body) async {
+    try {
+      var responseData = localMode
+          ? await rootBundle.loadString(Constants.localMessagesJsonPath)
+          : await serverApi.getMessages(body);
+
+      return handleResponse(MessagesResponseModel.fromJson(jsonDecode(responseData)), null);
+    } on DioException catch (dioException) {
+      return handleResponse(null, dioException);
+    } catch (exception) {
+      return handleResponse(null, exception as Exception);
+    }
+  }
+
+  /// 회의 목록 호출
+  Future<ApiResult<RoomsResponseModel?>> getRooms(RoomsRequestModel body) async {
+    try {
+      var responseData = localMode
+          ? await rootBundle.loadString(Constants.localRoomsJsonPath)
+          : await serverApi.getRooms(body);
+
+      return handleResponse(RoomsResponseModel.fromJson(jsonDecode(responseData)), null);
+    } on DioException catch (dioException) {
+      return handleResponse(null, dioException);
+    } catch (exception) {
+      return handleResponse(null, exception as Exception);
+    }
+  }
+
+  /// 사용자 목록 호출
+  Future<ApiResult<UsersResponseModel?>> getUsers(UsersRequestModel body) async {
+    try {
+      var responseData = localMode
+          ? await rootBundle.loadString(Constants.localUsersJsonPath)
+          : await serverApi.getUsers(body);
+
+      return handleResponse(UsersResponseModel.fromJson(jsonDecode(responseData)), null);
+    } on DioException catch (dioException) {
+      return handleResponse(null, dioException);
+    } catch (exception) {
+      return handleResponse(null, exception as Exception);
+    }
+  }
+
+}

--- a/lib/repositories/db_repository.dart
+++ b/lib/repositories/db_repository.dart
@@ -1,0 +1,321 @@
+import 'dart:convert';
+
+import 'package:flutter/foundation.dart';
+import 'package:mobile1_flutter_coding_test/commons/enums.dart';
+import 'package:mobile1_flutter_coding_test/models/message_model.dart';
+import 'package:mobile1_flutter_coding_test/models/room_model.dart';
+import 'package:mobile1_flutter_coding_test/models/user_model.dart';
+import 'package:sqflite/sqflite.dart';
+
+class DbRepository {
+
+  late Database db;
+
+  /// DB 초기화
+  Future open(String path) async {
+    db = await openDatabase(path, version: 1,
+        onCreate: (Database db, int version) async {
+          try {
+            await db.execute('''
+            create table messages (
+            roomId text not null,
+            messageId text primary key not null,
+            sender text not null,
+            content text not null,
+            timestamp integer not null)
+            ''');
+
+            await db.execute('''
+            create table rooms (
+            roomId text primary key not null,
+            roomName text not null,
+            creator text not null,
+            participants text not null,
+            createdAt integer not null,
+            thumbnailImage text
+            )
+            ''');
+
+            await db.execute('''
+            create table roomsLastMessage (
+              roomId text primary key not null,
+              sender text not null,
+              content text not null,
+              timestamp integer not null
+            )
+            ''');
+
+            await db.execute('''
+            create table users (
+              userId text primary key not null,
+              name text not null,
+              email text not null,
+              profilePicture text,
+              status int,
+              role int
+            )
+            ''');
+
+            debugPrint( 'db created!');
+          } catch ( e ) {
+            debugPrint ( e.toString() );
+          }
+        });
+  }
+
+  /// 메시지 추가
+  /// model: 추가할 메시지
+  Future<bool> insertMessage(MessageModel model) async {
+    try {
+      var jsonModel = model.toJson();
+      await db.insert('messages', jsonModel, conflictAlgorithm: ConflictAlgorithm.replace);
+    } catch ( e ) {
+      debugPrint ( e.toString());
+      return false;
+    }
+
+    return true;
+  }
+
+  /// 회의실 추가
+  /// model: 추가할 회의실
+  Future<bool> insertRoom(RoomModel model) async {
+    try {
+      var jsonModel = model.toJson();
+
+      // lastMessage 제외한 부분을 rooms에 넣음
+      // participants는 json 직렬화 하여 한 필드에 넣음
+      var modifiedJson = Map.fromEntries(
+          jsonModel.entries.where((element) => element.key != 'lastMessage')).map((key, value) {
+        if ( key == 'participants') {
+          return MapEntry(key, jsonEncode(value));
+        }
+        return MapEntry(key, value);
+      });
+      await db.insert('rooms', modifiedJson, conflictAlgorithm: ConflictAlgorithm.replace);
+      await insertLastMessage(modifiedJson['roomId'], model.lastMessage);
+
+    } catch ( e ) {
+      debugPrint ( e.toString());
+      return false;
+    }
+
+    return true;
+  }
+
+  /// 마지막 메시지 추가
+  /// roomId: 마지막 메시지를 입력시킬 회의실
+  /// lastMessage: 입력시킬 마지막 메시지
+  /// replace (기본값 false): true이면 입력값(lastMessage)으로 덮어쓴다.
+  Future<bool> insertLastMessage(String roomId, LastMessageModel lastMessage, {bool replace = false}) async {
+    try {
+      var lastMessageJson = lastMessage.toJson();
+      lastMessageJson['roomId'] = roomId;
+      await db.insert('roomsLastMessage', lastMessageJson, conflictAlgorithm: (replace == true) ? ConflictAlgorithm.replace : ConflictAlgorithm.ignore);
+    } catch ( e ) {
+      debugPrint(e.toString());
+      return false;
+    }
+
+    return true;
+  }
+
+  /// 사용자 추가
+  /// model: 추가할 사용자
+  Future<bool> insertUser(UserModel model) async {
+    try {
+      var jsonModel = model.toJson();
+      // User의 Status, Role는 숫자로 변환하여 DB에 저장한다.
+      var modifiedJsonModel = jsonModel.map( (key, value) {
+        if (key == 'status') {
+          return MapEntry(key, UserStatus.fromString(value).index);
+        } else if (key == 'role') {
+          return MapEntry(key, UserRole.fromString(value).index);
+        }
+
+        return MapEntry(key, value);
+      });
+      await db.insert('users', modifiedJsonModel, conflictAlgorithm: ConflictAlgorithm.replace);
+    } catch ( e ) {
+      debugPrint ( e.toString());
+      return false;
+    }
+
+    return true;
+  }
+
+  /// 메시지 1건 가져오기
+  /// roomId: 조회할 회의실 ID
+  Future<MessageModel?> fetchMessage(String roomId) async {
+    MessageModel? result;
+    try {
+      var queryResult = await db.query('messages', columns: null, where: '"roomId" = ?', whereArgs: [roomId]);
+      result = queryResult.map ( ( element ) {
+        return MessageModel.fromJson(element);
+      }).toList().firstOrNull;
+    } catch ( e ) {
+      debugPrint ( e.toString() );
+      return null;
+    }
+
+    return result;
+  }
+
+  /// 전체 메시지 가져오기
+  Future<List<MessageModel>?> fetchMessagesAll() async {
+    List<MessageModel>? result;
+    try {
+      var queryResult = await db.query('messages', orderBy: 'timestamp asc');
+      result = queryResult.map ( ( element ) {
+        return MessageModel.fromJson(element);
+      }).toList();
+    } catch ( e ) {
+      debugPrint ( e.toString() );
+      return null;
+    }
+
+    return result;
+  }
+
+  /// 회의실 1건 가져오기
+  /// roomId: 조회할 회의실 ID
+  Future<RoomModel?> fetchRoom(String roomId) async {
+    RoomModel? result;
+    try {
+      String sql = '''
+      select r.*, m.sender as lastSender, m.content as lastContent, m.timestamp as lastTimestamp
+      from rooms r
+      left join roomsLastMessage m
+      on r.roomId = m.roomId
+      where r.roomId = ?
+      ''';
+
+      var queryResult = await db.rawQuery(sql, [roomId]);
+
+      result = queryResult.map((element) {
+        var modified = element.map((key, value) {
+          if (key == 'participants' && value is String) {
+            return MapEntry(key, jsonDecode(value));
+          }
+
+          return MapEntry(key, value);
+        });
+
+        modified['lastMessage'] = {
+          'sender': modified['lastSender'],
+          'content': modified['lastContent'],
+          'timestamp': modified['lastTimestamp'],
+        };
+
+        // 필요없는 컬럼 제거
+        modified.remove('lastSender');
+        modified.remove('lastContent');
+        modified.remove('lastTimestamp');
+
+        return RoomModel.fromJson(modified);
+      }).toList().firstOrNull;
+    } catch ( e ) {
+      debugPrint ( e.toString() );
+      return null;
+    }
+
+    return result;
+  }
+
+  /// 회의실 전체 가져오기
+  Future<List<RoomModel>?> fetchRoomsAll() async {
+    List<RoomModel>? result;
+    try {
+      String sql = '''
+      select r.*, m.sender as lastSender, m.content as lastContent, m.timestamp as lastTimestamp
+      from rooms r
+      left join roomsLastMessage m
+      on r.roomId = m.roomId
+      order by m.timestamp desc
+      ''';
+
+      var queryResult = await db.rawQuery(sql);
+
+      result = queryResult.map((element) {
+        var modified = element.map((key, value) {
+          if (key == 'participants' && value is String) {
+            return MapEntry(key, jsonDecode(value));
+          }
+
+          return MapEntry(key, value);
+        });
+
+        modified['lastMessage'] = {
+          'sender': modified['lastSender'],
+          'content': modified['lastContent'],
+          'timestamp': modified['lastTimestamp'],
+        };
+
+        // 필요없는 컬럼 제거
+        modified.remove('lastSender');
+        modified.remove('lastContent');
+        modified.remove('lastTimestamp');
+
+        return RoomModel.fromJson(modified);
+      }).toList();
+    } catch ( e ) {
+      debugPrint ( e.toString() );
+      return null;
+    }
+
+    return result;
+  }
+
+  /// 회의실의 마지막 메시지 가져오기
+  /// roomId: 조회할 회의실 ID
+  Future<LastMessageModel?> fetchLastMessage(String roomId) async {
+    LastMessageModel? result;
+    try {
+     var queryResult = await db.query('roomsLastMessage',  where: '"roomId" = ?', whereArgs: [roomId]);
+     result = queryResult.map ( ( element ) {
+       return LastMessageModel.fromJson(element);
+     }).toList().firstOrNull;
+
+    } catch ( e ) {
+      debugPrint ( e.toString());
+      return null;
+    }
+
+    return result;
+  }
+
+  /// 사용자 1건 가져오기
+  /// userId: 조회할 사용자
+  Future<UserModel?> fetchUser(String userId) async {
+    UserModel? result;
+    try {
+      var queryResult = await db.query('users', columns: null, where: '"userId" = ?', whereArgs: [userId]);
+      result = queryResult.map ( ( element ) {
+        return UserModel.fromJson(element);
+      }).toList().firstOrNull;
+    } catch ( e ) {
+      debugPrint ( e.toString() );
+      return null;
+    }
+
+    return result;
+  }
+
+  /// 전체 사용자 가져오기
+  Future<List<UserModel>?> fetchUsersAll() async {
+    List<UserModel>? result;
+    try {
+      var queryResult = await db.query('users');
+      result = queryResult.map ( ( element ) {
+        return UserModel.fromJson(element);
+      }).toList();
+    } catch ( e ) {
+      debugPrint ( e.toString() );
+      return null;
+    }
+
+    return result;
+  }
+
+  Future close() async => db.close();
+}

--- a/lib/repositories/storage_repository.dart
+++ b/lib/repositories/storage_repository.dart
@@ -1,0 +1,25 @@
+import 'package:get_storage/get_storage.dart';
+
+class StorageRepository {
+
+  //TODO storage path
+  final GetStorage _storage = GetStorage();
+
+  bool _initialized = false;
+
+  Future<void> init() async {
+    var start = DateTime.now().millisecondsSinceEpoch;
+    if (!_initialized) {
+      await _storage.initStorage;
+      _initialized = true;
+    }
+  }
+
+  Future<void> setTest () async {
+    await _storage.write('test', 'test1234');
+  }
+
+  String? getTest() {
+    return _storage.read('test') ;
+  }
+}

--- a/lib/utils/utils.dart
+++ b/lib/utils/utils.dart
@@ -1,0 +1,70 @@
+import 'package:mobile1_flutter_coding_test/commons/enums.dart';
+import 'package:intl/intl.dart';
+
+DateTime dateTimeFromTimestamp(dynamic val) {
+  if ( val is String ) {
+    return DateTime.parse(val);
+  } else if ( val is int ) {
+    return DateTime.fromMillisecondsSinceEpoch(val);
+  }
+
+  throw Exception('dateTimeFromTimestamp는 String 또는 int만 받을 수 있음');
+}
+
+int timestampToInt(dynamic val) {
+
+  if ( val is String ) {
+    return DateTime.parse(val).millisecondsSinceEpoch;
+  } else if ( val is DateTime) {
+    return val.millisecondsSinceEpoch;
+  }
+
+  throw Exception('timestampToInt는 String 또는 DateTime만 받을 수 있음');
+
+}
+
+UserStatus userStatusFromValue(dynamic val) {
+  if ( val is String ) {
+    return UserStatus.fromString(val);
+  } else if ( val is int ) {
+    return UserStatus.values[val];
+  }
+
+  throw Exception('userStatusFromValue는 String 또는 int만 받을 수 있음');
+}
+
+UserRole userRoleFromValue(dynamic val) {
+  if ( val is String ) {
+    return UserRole.fromString(val);
+  } else if ( val is int ) {
+    return UserRole.values[val];
+  }
+
+  throw Exception('userRoleFromValue은 String 또는 int만 받을 수 있음');
+}
+
+String userStatusToString(UserStatus val) {
+  return val.value;
+}
+
+String userRoleToString(UserRole val) {
+  return val.value;
+}
+
+extension KoreanDateTimeFormat on DateTime {
+  String formatKorean({DateTime? now}) {
+    final DateTime _now = (now ?? DateTime.now()).toLocal();
+    final DateTime _dt  = this.toLocal();
+
+    final bool isToday =
+        _dt.year == _now.year && _dt.month == _now.month && _dt.day == _now.day;
+
+    if (isToday) {
+      return DateFormat('a hh:mm', 'ko').format(_dt);
+    } else {
+      return DateFormat('yyyy-MM-dd').format(_dt);
+    }
+
+    return toString();
+  }
+}

--- a/lib/view_models/base_page_view_model.dart
+++ b/lib/view_models/base_page_view_model.dart
@@ -1,0 +1,20 @@
+import 'package:get/get.dart';
+import 'package:mobile1_flutter_coding_test/view_models/base_view_model.dart';
+
+class BasePageViewModel extends BaseViewModel {
+
+  @override
+  void onInit() {
+    // TODO: implement onInit
+    super.onInit();
+  }
+
+  @override
+  void dispose() {
+    // TODO: implement dispose
+    super.dispose();
+  }
+
+  final tabIndex = 0.obs;
+
+}

--- a/lib/view_models/base_view_model.dart
+++ b/lib/view_models/base_view_model.dart
@@ -1,0 +1,12 @@
+import 'package:get/get.dart';
+
+abstract class BaseViewModel extends GetxController {
+
+  @override
+  void onInit() {
+    // TODO: implement onInit
+    super.onInit();
+  }
+
+
+}

--- a/lib/view_models/chat_room_view_model.dart
+++ b/lib/view_models/chat_room_view_model.dart
@@ -1,0 +1,95 @@
+import 'package:flutter/material.dart';
+import 'package:get/get.dart';
+import 'package:mobile1_flutter_coding_test/commons/main_module.dart';
+import 'package:mobile1_flutter_coding_test/models/message_model.dart';
+import 'package:mobile1_flutter_coding_test/models/room_model.dart';
+import 'package:mobile1_flutter_coding_test/models/user_model.dart';
+import 'package:mobile1_flutter_coding_test/view_models/base_view_model.dart';
+
+class ChatRoomViewModel extends BaseViewModel {
+
+  RxList<MessageModel> messagesList = <MessageModel>[].obs;
+  ScrollController scrollController = ScrollController();
+  late RoomModel _room;
+  final FocusNode focusNode = FocusNode();
+
+  @override
+  void onInit() {
+    // TODO: implement onInit
+    super.onInit();
+  }
+
+  @override
+  void dispose() {
+    // TODO: implement dispose
+    super.dispose();
+  }
+  void getMessages( RoomModel room ) {
+    _room = room;
+    var getMessages = MainModule.instance.messagesList.where( (element) { return element.roomId == _room.roomId; });
+
+    if ( getMessages.isNotEmpty) {
+      messagesList.addAll(getMessages);
+    }
+  }
+
+  Future<bool> sendMessage ( String message ) async {
+
+    late String newMsgId;
+    var lastMessage = MainModule.instance.messagesList.lastOrNull;
+
+   if ( lastMessage == null ) {
+     newMsgId = 'msg1';
+   } else {
+     final regex = RegExp(r'^msg(\d+)$');
+     final match = regex.firstMatch(lastMessage.messageId);
+
+     if (match != null) {
+       final number = int.parse(match.group(1)!);
+       final incremented = number + 1;
+       newMsgId = 'msg$incremented';
+     } else {
+       newMsgId = 'msg1';
+     }
+   }
+
+    var messageModel = MessageModel(
+      roomId: _room.roomId,
+      messageId: newMsgId,
+      sender: MainModule.instance.currentUser.userId,
+      content: message,
+      timestamp: DateTime.now().toUtc()
+    );
+
+
+    bool result = await MainModule.instance.sendMessage(messageModel);
+    messagesList.add(messageModel);
+
+    if ( result == true ) {
+      0.5.delay ( () {
+        scrollController.jumpTo(scrollController.position.maxScrollExtent);
+      });
+    }
+
+    return result;
+  }
+
+  UserModel? findUser ( String userId ) {
+    return MainModule.instance.usersList.firstWhereOrNull ( (element) { return element.userId == userId; } );
+  }
+
+  Future<List<UserModel>> getParticipants () async {
+    List<UserModel> list = [];
+
+    list.add(MainModule.instance.currentUser);
+
+    for ( var userId in _room.participants ) {
+      var user = await MainModule.instance.dbRepository.fetchUser(userId);
+      if ( user != null ) {
+        list.add( user );
+      }
+    }
+
+    return list;
+  }
+}

--- a/lib/view_models/rooms_view_model.dart
+++ b/lib/view_models/rooms_view_model.dart
@@ -1,0 +1,21 @@
+import 'package:flutter/material.dart';
+import 'package:mobile1_flutter_coding_test/commons/main_module.dart';
+import 'package:mobile1_flutter_coding_test/view_models/base_view_model.dart';
+
+class RoomsViewModel extends BaseViewModel {
+
+  @override
+  void onInit() {
+    // TODO: implement onInit
+    super.onInit();
+  }
+
+  @override
+  void dispose() {
+    // TODO: implement dispose
+    super.dispose();
+  }
+
+  ScrollController scrollController = ScrollController();
+  get roomsList => MainModule.instance.roomsList;
+}

--- a/lib/view_models/users_detail_view_model.dart
+++ b/lib/view_models/users_detail_view_model.dart
@@ -1,0 +1,16 @@
+import 'package:mobile1_flutter_coding_test/view_models/base_view_model.dart';
+
+class UsersDetailViewModel extends BaseViewModel {
+
+  @override
+  void onInit() {
+    // TODO: implement onInit
+    super.onInit();
+  }
+
+  @override
+  void dispose() {
+    // TODO: implement dispose
+    super.dispose();
+  }
+}

--- a/lib/view_models/users_view_model.dart
+++ b/lib/view_models/users_view_model.dart
@@ -1,0 +1,19 @@
+import 'package:flutter/material.dart';
+import 'package:mobile1_flutter_coding_test/view_models/base_view_model.dart';
+
+class UsersViewModel extends BaseViewModel {
+
+  @override
+  void onInit() {
+    // TODO: implement onInit
+    super.onInit();
+  }
+
+  @override
+  void dispose() {
+    // TODO: implement dispose
+    super.dispose();
+  }
+
+  ScrollController scrollController = ScrollController();
+}

--- a/lib/views/base_page_view.dart
+++ b/lib/views/base_page_view.dart
@@ -1,0 +1,63 @@
+import 'package:flutter/material.dart';
+import 'package:get/get_state_manager/src/rx_flutter/rx_obx_widget.dart';
+import 'package:intl/date_symbol_data_local.dart';
+import 'package:mobile1_flutter_coding_test/view_models/base_page_view_model.dart';
+import 'package:mobile1_flutter_coding_test/views/base_view.dart';
+import 'package:mobile1_flutter_coding_test/views/rooms_view.dart';
+import 'package:mobile1_flutter_coding_test/views/users_view.dart';
+import 'package:mobile1_flutter_coding_test/widgets/base_content_widget.dart';
+import 'package:mobile1_flutter_coding_test/widgets/base_tab_widget.dart';
+
+class BasePageView extends BaseView<BasePageViewModel> {
+  const BasePageView({super.key});
+
+  @override
+  void initState(BasePageViewModel vm) {
+    // TODO: implement initState
+    super.initState(vm);
+  }
+
+  @override
+  void dispose(BasePageViewModel vm) {
+    // TODO: implement dispose
+    super.dispose(vm);
+  }
+
+  @override
+  Widget builder(BuildContext context, BasePageViewModel vm) {
+    initializeDateFormatting(Localizations.localeOf(context).languageCode);
+    return Obx( () {
+        return BaseContentWidget(
+
+          title: controller.tabIndex.value == 0 ? '사용자' : '회의실',
+          useBackButton: false,
+          bottomNavigationBar: BottomNavigationBar(
+            currentIndex: controller.tabIndex.value,
+            onTap: (index) {
+              controller.tabIndex.value = index;
+            },
+            items: const [
+              BottomNavigationBarItem(icon: Icon(Icons.people), label: '사용자'),
+              BottomNavigationBarItem(icon: Icon(Icons.chat_rounded), label: '회의실'),
+            ],
+          ),
+          child: currentTabPage,
+        );
+      },
+    );
+  }
+
+  Widget get currentTabPage {
+    switch (controller.tabIndex.value) {
+      case 0:
+        return const BaseTabWidget(child:UsersView());
+      case 1:
+        return const BaseTabWidget(child:RoomsView());
+    }
+    return const BaseTabWidget(child:UsersView());
+  }
+
+  @override
+  BasePageViewModel? get vmProvider => BasePageViewModel();
+
+}

--- a/lib/views/base_view.dart
+++ b/lib/views/base_view.dart
@@ -1,0 +1,46 @@
+import 'package:flutter/material.dart';
+import 'package:get/get.dart';
+import 'package:mobile1_flutter_coding_test/view_models/base_view_model.dart';
+
+abstract class BaseView<V extends BaseViewModel> extends GetView<V> {
+  const BaseView({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    return GetBuilder<V>(
+        tag: tag,
+        initState: _initState,
+        dispose: _dispose,
+        builder: (_) {
+          assert(_.hashCode == controller.hashCode);
+          return builder(context, controller);
+        },
+      );
+  }
+
+  // LazyVMProvider<V>? get lazyVmProvider => null;
+  V? get vmProvider => null;
+
+  void _initState(GetBuilderState<V> state) {
+
+    // final vm = vmProvider ?? lazyVmProvider?.call();
+    final vm = vmProvider;
+    if (!Get.isRegistered<V>(tag: tag) && vm != null) {
+      Get.put<V>(vm, tag: tag);
+    }
+
+    initState(controller);
+  }
+
+
+  void _dispose(GetBuilderState<V> state) {
+    if (Get.isRegistered<V>()) {
+      dispose(controller);
+    }
+  }
+
+  void initState(V vm) {}
+  void dispose(V vm) {}
+
+  Widget builder(BuildContext context, V vm);
+}

--- a/lib/views/chat_room_view.dart
+++ b/lib/views/chat_room_view.dart
@@ -1,0 +1,229 @@
+import 'package:bubble/bubble.dart';
+import 'package:cached_network_image/cached_network_image.dart';
+import 'package:flutter/material.dart';
+import 'package:get/get.dart';
+import 'package:mobile1_flutter_coding_test/commons/main_module.dart';
+import 'package:mobile1_flutter_coding_test/models/message_model.dart';
+import 'package:mobile1_flutter_coding_test/models/room_model.dart';
+import 'package:mobile1_flutter_coding_test/models/user_model.dart';
+import 'package:mobile1_flutter_coding_test/utils/utils.dart';
+import 'package:mobile1_flutter_coding_test/view_models/chat_room_view_model.dart';
+import 'package:mobile1_flutter_coding_test/views/base_view.dart';
+import 'package:mobile1_flutter_coding_test/views/users_detail_view.dart';
+import 'package:mobile1_flutter_coding_test/widgets/base_content_widget.dart';
+import 'package:mobile1_flutter_coding_test/widgets/base_tile_widget.dart';
+import 'package:mobile1_flutter_coding_test/widgets/chat_input_bar_widget.dart';
+import 'package:mobile1_flutter_coding_test/widgets/user_role_widget.dart';
+import 'package:mobile1_flutter_coding_test/widgets/user_status_widget.dart';
+
+class ChatRoomView extends BaseView<ChatRoomViewModel> {
+  ChatRoomView({super.key, required this.room});
+  final RoomModel room;
+  OverlayEntry? _overlayEntry;
+
+  @override
+  void initState(ChatRoomViewModel vm) {
+    // TODO: implement initState
+    controller.getMessages(room);
+    super.initState(vm);
+  }
+
+  @override
+  void dispose(ChatRoomViewModel vm) {
+    // TODO: implement dispose
+    super.dispose(vm);
+  }
+
+  @override
+  Widget builder(BuildContext context, ChatRoomViewModel vm) {
+    WidgetsBinding.instance.addPostFrameCallback((_) {
+      controller.scrollController.jumpTo(controller.scrollController.position.maxScrollExtent);
+    });
+
+    final _overlay = Overlay.of(context);
+    final bottomInset = MediaQuery.of(context).viewInsets.bottom;
+
+      return BaseContentWidget(
+          title: room.roomName,
+          action: [
+            IconButton(
+              icon: const Icon(Icons.menu),
+              onPressed: () async {
+                var usersList = await controller.getParticipants();
+                _overlayEntry = OverlayEntry(
+                  builder: (context) => Stack(
+                    children: [
+                      GestureDetector(
+                        onTap: () => _overlayEntry!.remove(),
+                        behavior: HitTestBehavior.opaque,
+                        child: Container(color: Colors.black12),
+                      ),
+                      Positioned(
+                        right: 0,
+                        left: null,
+                        top: 0,
+                        bottom: 0,
+                        child: Material(
+                          child: Container(
+                            width: MediaQuery.of(context).size.width * 0.5,
+                            height: MediaQuery.of(context).size.height,
+                            color: Colors.transparent,
+                            child: Column(
+                              children: [
+                                SizedBox(height:30),
+                                Text ( '참여자 목록 (${usersList.length}명)',
+                                    style: TextStyle( fontWeight: FontWeight.bold)),
+                                SizedBox(height:3),
+                                Expanded(
+                                  child: ListView.separated(
+                                      controller: controller.scrollController,
+                                      scrollDirection: Axis.vertical,
+                                      itemCount: usersList.length,
+                                      shrinkWrap: true,
+                                      separatorBuilder: (_, __) => const SizedBox(height: 5, child: Divider(height: 1)),
+                                      itemBuilder: (context, index) {
+                                        UserModel user = usersList[index];
+
+                                        return BaseTileWidget(
+                                            onTap: () async {
+                                              _overlayEntry!.remove();
+                                              Get.to(UsersDetailView(user: user));
+                                            },
+                                            thumbnailPath: user.profilePicture,
+                                            content: Column(
+                                              mainAxisAlignment: MainAxisAlignment.center,
+                                              crossAxisAlignment: CrossAxisAlignment.start,
+                                              children: [
+                                                Column(
+                                                  crossAxisAlignment: CrossAxisAlignment.start,
+                                                  children: [
+                                                    Text(user.name + (user.userId == MainModule.instance.currentUser.userId ? ' (나)' : '' )),
+                                                    Row(
+                                                        children: [
+                                                          UserRoleWidget(userRole: user.role),
+                                                          UserStatusWidget(userStatus: user.status)
+                                                        ]
+                                                    )
+                                                  ],
+                                                ),
+                                              ],
+                                            ));
+                                      })
+                                ),
+                              ],
+                            ),
+                          ),
+                        ),
+                      ),
+                    ],
+                  ),
+                );
+
+                _overlay.insert(_overlayEntry!);
+              },
+            ),
+          ],
+          child: Padding(
+            padding: EdgeInsets.symmetric(horizontal: 15, vertical: 5),
+              child: Column(
+              children: [
+                Expanded(
+                  child: Padding(
+                    padding: EdgeInsets.only(bottom: 10),
+                    child: Obx ( () {
+                      final messagesList = controller.messagesList;
+                      return ListView.separated(
+                        controller: controller.scrollController,
+                        scrollDirection: Axis.vertical,
+                        itemCount: messagesList.length,
+                        shrinkWrap: true,
+                        separatorBuilder: (_, __) => const SizedBox(height: 10 ),
+                        itemBuilder: (context, index) {
+                          MessageModel message = messagesList[index];
+                          UserModel? user = controller.findUser(message.sender);
+
+                          return Container(
+                              // height: 75,
+                              child: Directionality(
+                                textDirection: user!.userId == MainModule.instance.currentUser.userId ? TextDirection.rtl: TextDirection.ltr,
+                                child: Row(
+                                  children: [
+                                    SizedBox(
+                                        width: 75,
+                                        height: 75,
+                                        child: Center(
+                                          child: ( user.profilePicture != null && user.profilePicture!.isNotEmpty) ?
+                                          InkWell(
+                                            onTap: () {
+                                              Get.to(UsersDetailView(user: user));
+                                            },
+                                            child: Container(
+                                                width: 50,
+                                                height: 50,
+                                                decoration:
+                                                BoxDecoration(
+                                                  shape: BoxShape.rectangle,
+                                                  borderRadius: BorderRadius.circular(10.0),
+                                                  color: Colors.transparent,
+                                                  image: DecorationImage(
+                                                      image: CachedNetworkImageProvider(
+                                                          user.profilePicture!,
+                                                          maxWidth: 50,
+                                                          maxHeight: 50,
+                                                          errorListener: (_) {
+
+                                                          })),
+                                                )),
+                                          ) : Icon(Icons.account_circle, size: 50, color: Colors.grey),
+                                        )),
+                                    Expanded(child: Column(
+                                      mainAxisAlignment: MainAxisAlignment.center,
+                                      crossAxisAlignment: CrossAxisAlignment.start,
+                                      children: [
+                                        Row(
+                                          children: [
+                                            Directionality(
+                                                textDirection: TextDirection.ltr,
+                                                child: Text(user.name)),
+                                            UserRoleWidget(userRole: user.role),
+                                          ],
+                                        ),
+                                          SizedBox(height:5),
+                                          Bubble(
+                                            nip: user.userId == MainModule.instance.currentUser.userId ? BubbleNip.rightTop: BubbleNip.leftTop,
+                                            color: user.userId == MainModule.instance.currentUser.userId ? Colors.purple.shade100 : Colors.purple.shade50,
+                                            child: Directionality(
+                                              textDirection: TextDirection.ltr,
+                                              child: Column(
+                                                crossAxisAlignment: CrossAxisAlignment.start,
+                                                children: [
+                                                  Text(message.content),
+                                                  Text(message.timestamp.formatKorean())
+                                                ],
+                                              ),
+                                            ),
+                                          ),
+                                      ],
+                                    )),
+                                  ],
+                                ),
+                              ));
+                        });}),
+                  ),
+                ),
+                Padding(
+                  padding: const EdgeInsets.symmetric(vertical: 10),
+                  child: ChatInputBarWidget(
+                    focusNode: controller.focusNode,
+                    onSend: (String message) async {
+                    await controller.sendMessage(message);
+                  }) ),
+              ],
+            ),
+          ));
+  }
+
+  @override
+  ChatRoomViewModel? get vmProvider => ChatRoomViewModel();
+
+}

--- a/lib/views/rooms_view.dart
+++ b/lib/views/rooms_view.dart
@@ -1,0 +1,92 @@
+import 'package:cached_network_image/cached_network_image.dart';
+import 'package:flutter/material.dart';
+import 'package:get/get.dart';
+import 'package:mobile1_flutter_coding_test/models/room_model.dart';
+import 'package:mobile1_flutter_coding_test/view_models/rooms_view_model.dart';
+import 'package:mobile1_flutter_coding_test/views/base_view.dart';
+import 'package:mobile1_flutter_coding_test/views/chat_room_view.dart';
+import 'package:mobile1_flutter_coding_test/utils/utils.dart';
+
+class RoomsView extends BaseView<RoomsViewModel> {
+  const RoomsView({super.key});
+
+  @override
+  void initState(RoomsViewModel vm) {
+    // TODO: implement initState
+    super.initState(vm);
+  }
+
+  @override
+  void dispose(RoomsViewModel vm) {
+    // TODO: implement dispose
+    super.dispose(vm);
+  }
+
+  @override
+  Widget builder(BuildContext context, RoomsViewModel vm) {
+    return Obx ( () {
+      var roomsList = controller.roomsList;
+      return ListView.separated(
+          controller: controller.scrollController,
+          scrollDirection: Axis.vertical,
+          itemCount: roomsList.length,
+          shrinkWrap: true,
+          separatorBuilder: (_, __) => const SizedBox(height: 5, child: Divider(height: 1)),
+          itemBuilder: (context, index) {
+            RoomModel room = roomsList[index];
+
+            return InkWell(
+                onTap: () async {
+                  Get.to(ChatRoomView(room: room));
+                },
+                child: Container(
+                    height: 85,
+                    child: Row(
+                      children: [
+                        SizedBox(
+                            width: 85,
+                            height: 85,
+                            child: Center(
+                              child: (room.thumbnailImage != null && room.thumbnailImage!.isNotEmpty) ?
+                              Container(
+                                  width: 50,
+                                  height: 50,
+                                  decoration:
+                                  BoxDecoration(
+                                    shape: BoxShape.rectangle,
+                                    borderRadius: BorderRadius.circular(10.0),
+                                    color: Colors.transparent,
+                                    image: DecorationImage(
+                                        image: CachedNetworkImageProvider(
+                                            room.thumbnailImage!,
+                                            maxWidth: 50,
+                                            maxHeight: 50,
+                                            errorListener: (_) {
+
+                                            })),
+                                  )) : Icon(Icons.chat, size: 50, color: Colors.grey),
+                            )),
+                        Expanded(child: Column(
+                          mainAxisAlignment: MainAxisAlignment.center,
+                          crossAxisAlignment: CrossAxisAlignment.start,
+                          children: [
+                            Text ( room.roomName,
+                            style: TextStyle( fontWeight: FontWeight.bold)),
+                            Text ( room.lastMessage.content ),
+                            Text ('마지막 메시지: ${room.lastMessage.timestamp.formatKorean()}',
+                            style: TextStyle(color: Colors.black54)
+                            ),
+                            Text ('생성 일시: ${room.createdAt.formatKorean()}',
+                            style: TextStyle(color: Colors.black54))
+                          ],
+                        )),
+                      ],
+                    )));
+          });
+    });
+  }
+
+  @override
+  RoomsViewModel? get vmProvider => RoomsViewModel();
+
+}

--- a/lib/views/users_detail_view.dart
+++ b/lib/views/users_detail_view.dart
@@ -1,0 +1,105 @@
+import 'package:cached_network_image/cached_network_image.dart';
+import 'package:flutter/material.dart';
+import 'package:mobile1_flutter_coding_test/commons/enums.dart';
+import 'package:mobile1_flutter_coding_test/models/user_model.dart';
+import 'package:mobile1_flutter_coding_test/view_models/users_detail_view_model.dart';
+import 'package:mobile1_flutter_coding_test/views/base_view.dart';
+import 'package:mobile1_flutter_coding_test/widgets/base_content_widget.dart';
+import 'package:mobile1_flutter_coding_test/widgets/user_role_widget.dart';
+import 'package:mobile1_flutter_coding_test/widgets/user_status_widget.dart';
+
+class UsersDetailView extends BaseView<UsersDetailViewModel> {
+  const UsersDetailView({super.key, required this.user});
+  final UserModel user;
+
+@override
+  void initState(UsersDetailViewModel vm) {
+    // TODO: implement initState
+    super.initState(vm);
+  }
+
+  @override
+  void dispose(UsersDetailViewModel vm) {
+    // TODO: implement dispose
+    super.dispose(vm);
+  }
+
+  @override
+  Widget builder(BuildContext context, UsersDetailViewModel vm) {
+
+    return BaseContentWidget(
+        title: '유저 정보',
+        child: Padding(
+          padding: EdgeInsets.symmetric(horizontal: 15, vertical: 5),
+          child: Column(
+            children: [
+              SizedBox( height: 15),
+              Align(
+                alignment: Alignment.centerLeft,
+                child: SizedBox(
+                    width: 125,
+                    height: 125,
+                    child: (user.profilePicture != null && user.profilePicture!.isNotEmpty) ?
+                    Container(
+                        width: 125,
+                        height: 125,
+                        decoration:
+                        BoxDecoration(
+                          shape: BoxShape.rectangle,
+                          borderRadius: BorderRadius.circular(15.0),
+                          color: Colors.transparent,
+                          image: DecorationImage(
+                              image: CachedNetworkImageProvider(
+                                  user.profilePicture!,
+                                  maxWidth: 125,
+                                  maxHeight: 125,
+                                  errorListener: (_) {
+
+                                  })),
+                        )) : Icon(Icons.account_circle, size: 125, color: Colors.grey)),
+              ),
+              Expanded(child: Align(
+                alignment: Alignment.topLeft,
+                child: Column(
+                  crossAxisAlignment: CrossAxisAlignment.start,
+                  children: [
+                    SizedBox(height: 15),
+                    Text(
+                        style: TextStyle (
+                          fontSize: 30,
+                        ),
+                        user.name),
+                    SizedBox(height:10),
+                    Text (user.email),
+                    SizedBox(height:10),
+                    Row(
+                      children: [
+                        Text (
+                          '유저 타입: ${user.role == UserRole.admin ? '관리자' : user.role == UserRole.member ? '일반유저' : '오류'}'
+                        ),
+                        UserRoleWidget(userRole:user.role)
+                      ],
+                    ),
+                    SizedBox(height: 10),
+                    Row(
+                      children: [
+                        Text(
+                            '유저 상태: ${user.status == UserStatus.offline ? '오프라인'
+                                : user.status == UserStatus.online ? '온라인'
+                                : user.status == UserStatus.doNotDisturb ? '방해금지'
+                                : user.status == UserStatus.away ? '이탈' : '오류'}'),
+                        UserStatusWidget(userStatus: user.status)
+                      ],
+                    ),
+                  ],
+                ),
+              )),
+            ],
+          ),
+        ));
+  }
+
+  @override
+  UsersDetailViewModel? get vmProvider => UsersDetailViewModel();
+
+}

--- a/lib/views/users_view.dart
+++ b/lib/views/users_view.dart
@@ -1,0 +1,67 @@
+import 'package:flutter/material.dart';
+import 'package:get/get.dart';
+import 'package:mobile1_flutter_coding_test/commons/main_module.dart';
+import 'package:mobile1_flutter_coding_test/models/user_model.dart';
+import 'package:mobile1_flutter_coding_test/view_models/users_view_model.dart';
+import 'package:mobile1_flutter_coding_test/views/base_view.dart';
+import 'package:mobile1_flutter_coding_test/views/users_detail_view.dart';
+import 'package:mobile1_flutter_coding_test/widgets/base_tile_widget.dart';
+import 'package:mobile1_flutter_coding_test/widgets/user_role_widget.dart';
+import 'package:mobile1_flutter_coding_test/widgets/user_status_widget.dart';
+
+class UsersView extends BaseView<UsersViewModel> {
+  const UsersView({super.key});
+
+  @override
+  void initState(UsersViewModel vm) {
+    // TODO: implement initState
+    super.initState(vm);
+  }
+
+  @override
+  void dispose(UsersViewModel vm) {
+    // TODO: implement dispose
+    super.dispose(vm);
+  }
+
+  @override
+  Widget builder(BuildContext context, UsersViewModel vm) {
+    return Obx(() {
+      var usersList = MainModule.instance.usersList;
+
+      return ListView.separated(
+          controller: controller.scrollController,
+          scrollDirection: Axis.vertical,
+          itemCount: usersList.length,
+          shrinkWrap: true,
+          separatorBuilder: (_, __) => const SizedBox(height: 5, child: Divider(height: 1)),
+          itemBuilder: (context, index) {
+            UserModel user = usersList[index];
+
+            return BaseTileWidget(
+              onTap: () async {
+                Get.to(UsersDetailView(user: user));
+              },
+              thumbnailPath: user.profilePicture,
+              content: Column(
+                mainAxisAlignment: MainAxisAlignment.center,
+                crossAxisAlignment: CrossAxisAlignment.start,
+                children: [
+                  Row(
+                    children: [
+                      Text(user.name + (user.userId == MainModule.instance.currentUser.userId ? ' (나)' : '' )),
+                      UserRoleWidget(userRole: user.role),
+                      UserStatusWidget(userStatus: user.status)
+                    ],
+                  ),
+                  Text (user.email),
+                ],
+              )
+            );
+          });
+    });
+  }
+
+  @override
+  UsersViewModel? get vmProvider => UsersViewModel();
+}

--- a/lib/widgets/base_content_widget.dart
+++ b/lib/widgets/base_content_widget.dart
@@ -1,0 +1,63 @@
+import 'package:flutter/material.dart';
+import 'package:get/get.dart';
+
+class BaseContentWidget extends StatelessWidget {
+  BaseContentWidget({
+    super.key,
+    this.title,
+    required this.child,
+    this.bottomNavigationBar,
+    this.useBackButton = true,
+    this.action,
+  });
+  final dynamic title;
+  final Widget child;
+  final Widget? bottomNavigationBar;
+  final bool useBackButton;
+  final List<Widget>? action;
+
+  final GlobalKey<ScaffoldState> _key = GlobalKey();
+
+  @override
+  Widget build(BuildContext context) {
+
+    return Scaffold(
+      resizeToAvoidBottomInset: true,
+      backgroundColor: Color(0xFFF6F6F6),
+      appBar:AppBar(
+        scrolledUnderElevation: 0,
+        leading: useBackButton == true ? IconButton(
+            icon: _backButton(),
+            onPressed: () {Get.back();}
+        ) : null,
+        automaticallyImplyLeading: true,
+        title: title is String
+            ? Text(
+          title,
+          style: TextStyle(
+            fontSize: 21,
+            height:1.0,),
+          strutStyle: StrutStyle(
+            fontSize: 21,
+            height: 1.0,
+            forceStrutHeight: true,
+          ),)
+            : title is Widget
+            ? title
+            : null,
+        elevation: 0,
+        actions: action
+      ),
+      body: SafeArea(
+        top: true,    // 상단 상태바 영역 보호
+        bottom: true, // 하단 네비게이션바 영역 보호
+        child: child,
+      ),
+      bottomNavigationBar: bottomNavigationBar,
+    );
+  }
+}
+
+Widget _backButton() {
+  return const Icon(Icons.arrow_back);
+}

--- a/lib/widgets/base_tab_widget.dart
+++ b/lib/widgets/base_tab_widget.dart
@@ -1,0 +1,17 @@
+import 'package:flutter/material.dart';
+
+class BaseTabWidget extends StatelessWidget {
+  const BaseTabWidget({super.key, required this.child});
+
+  final Widget child;
+
+  @override
+  Widget build(BuildContext context) {
+    return SafeArea(
+      child: SingleChildScrollView(
+        padding: const EdgeInsets.all(16),
+        child: child
+      ),
+    );
+  }
+}

--- a/lib/widgets/base_tile_widget.dart
+++ b/lib/widgets/base_tile_widget.dart
@@ -1,0 +1,47 @@
+import 'package:cached_network_image/cached_network_image.dart';
+import 'package:flutter/material.dart';
+
+class BaseTileWidget extends StatelessWidget {
+  const BaseTileWidget({super.key, this.onTap, this.thumbnailPath, required this.content});
+
+  final VoidCallback? onTap;
+  final String? thumbnailPath;
+  final Widget content;
+
+  @override
+  Widget build(BuildContext context) {
+    return InkWell(
+        onTap: onTap,
+        child: SizedBox(
+          height: 75,
+          child: Row(
+            children: [
+              SizedBox(
+                  width: 75,
+                  height: 75,
+                  child: Center(
+                    child: (thumbnailPath != null) ?
+                    Container(
+                        width: 50,
+                        height: 50,
+                        decoration:
+                        BoxDecoration(
+                          shape: BoxShape.rectangle,
+                          borderRadius: BorderRadius.circular(10.0),
+                          color: Colors.transparent,
+                          image: DecorationImage(
+                              image: CachedNetworkImageProvider(
+                                  thumbnailPath!,
+                                  maxWidth: 50,
+                                  maxHeight: 50,
+                                  errorListener: (_) {
+
+                                  })),
+                        )) : const Icon(Icons.account_circle, size: 50, color: Colors.grey),
+                  )),
+              Expanded(child: content),
+            ],
+          )),
+    );
+  }
+}

--- a/lib/widgets/chat_input_bar_widget.dart
+++ b/lib/widgets/chat_input_bar_widget.dart
@@ -1,0 +1,47 @@
+import 'package:flutter/material.dart';
+
+class ChatInputBarWidget extends StatefulWidget {
+  final void Function(String) onSend;
+  final FocusNode focusNode;
+
+  const ChatInputBarWidget({Key? key, required this.onSend, required this.focusNode}) : super(key: key);
+
+  @override
+  State<ChatInputBarWidget> createState() => _ChatInputBarWidgetState();
+}
+
+class _ChatInputBarWidgetState extends State<ChatInputBarWidget> {
+  final TextEditingController _controller = TextEditingController();
+
+  void _handleSend([String? submitted]) {
+    final text = (submitted ?? _controller.text).trim();
+    if (text.isEmpty) return;
+    widget.onSend(text);
+    _controller.clear();
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return SafeArea(
+      child: Row(
+        children: [
+          Expanded(
+            child: TextField(
+              focusNode: widget.focusNode,
+              controller: _controller,
+              onSubmitted: _handleSend, // 완료 버튼 누르면 호출
+              decoration: const InputDecoration(
+                hintText: '메시지 입력...',
+                border: OutlineInputBorder(),
+              ),
+            ),
+          ),
+          IconButton(
+            icon: const Icon(Icons.send),
+            onPressed: _handleSend,
+          ),
+        ],
+      ),
+    );
+  }
+}

--- a/lib/widgets/user_role_widget.dart
+++ b/lib/widgets/user_role_widget.dart
@@ -1,0 +1,17 @@
+import 'package:flutter/material.dart';
+import 'package:mobile1_flutter_coding_test/commons/enums.dart';
+
+class UserRoleWidget extends StatelessWidget {
+  const UserRoleWidget({super.key, required this.userRole});
+
+  final UserRole userRole;
+
+  @override
+  Widget build(BuildContext context) {
+    if ( userRole == UserRole.admin) {
+      return const Icon(Icons.handyman, color: Colors.blueGrey);
+    }
+
+    return const SizedBox.shrink();
+  }
+}

--- a/lib/widgets/user_status_widget.dart
+++ b/lib/widgets/user_status_widget.dart
@@ -1,0 +1,26 @@
+import 'package:flutter/material.dart';
+import 'package:mobile1_flutter_coding_test/commons/enums.dart';
+
+class UserStatusWidget extends StatelessWidget {
+  const UserStatusWidget({super.key, required this.userStatus});
+
+  final UserStatus userStatus;
+
+  @override
+  Widget build(BuildContext context) {
+
+    switch ( userStatus ) {
+      case UserStatus.offline:
+        return const Icon(Icons.offline_bolt_outlined, color: Colors.grey);
+      case UserStatus.online:
+        return const Icon(Icons.offline_bolt_outlined, color: Colors.green);
+      case UserStatus.doNotDisturb:
+        return const Icon(Icons.do_not_disturb_on, color: Colors.red);
+      case UserStatus.away:
+        return const Icon(Icons.close, color: Colors.grey);
+      default:
+    }
+
+    return const SizedBox.shrink();
+  }
+}

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -56,7 +56,7 @@ dev_dependencies:
   # activated in the `analysis_options.yaml` file located at the root of your
   # package. See that file for information about deactivating specific lint
   # rules and activating additional ones.
-  flutter_lints: ^4.0.0
+  flutter_lints: ^6.0.0
 
   build_runner:
   retrofit_generator:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -36,6 +36,17 @@ dependencies:
   # Use with the CupertinoIcons class for iOS style icons.
   cupertino_icons: ^1.0.8
 
+  json_serializable:
+  json_annotation:
+  get:
+  get_storage:
+  dio:
+  retrofit:
+  sqflite:
+  cached_network_image:
+  intl:
+  bubble:
+
 dev_dependencies:
   flutter_test:
     sdk: flutter
@@ -46,6 +57,9 @@ dev_dependencies:
   # package. See that file for information about deactivating specific lint
   # rules and activating additional ones.
   flutter_lints: ^4.0.0
+
+  build_runner:
+  retrofit_generator:
 
 # For information on the generic Dart part of this file, see the
 # following page: https://dart.dev/tools/pub/pubspec
@@ -62,6 +76,9 @@ flutter:
   # assets:
   #   - images/a_dot_burr.jpeg
   #   - images/a_dot_ham.jpeg
+
+  assets:
+    - api/
 
   # An image asset can refer to one or more resolution-specific "variants", see
   # https://flutter.dev/to/resolution-aware-images

--- a/test/repo_test.dart
+++ b/test/repo_test.dart
@@ -1,0 +1,44 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:flutter/services.dart' show rootBundle;
+import 'package:mobile1_flutter_coding_test/api/api_result.dart';
+import 'package:mobile1_flutter_coding_test/api/models/requests/messages_request_model.dart';
+import 'package:mobile1_flutter_coding_test/api/models/requests/rooms_request_model.dart';
+import 'package:mobile1_flutter_coding_test/api/models/requests/users_request_model.dart';
+import 'package:mobile1_flutter_coding_test/api/models/responses/messages_response_model.dart';
+import 'package:mobile1_flutter_coding_test/api/models/responses/rooms_response_model.dart';
+import 'package:mobile1_flutter_coding_test/api/models/responses/users_response_model.dart';
+import 'package:mobile1_flutter_coding_test/repositories/api_repository.dart';
+
+void main() {
+  group('원격 Json 호출 테스트', () {
+    late ApiRepository _apiRepository;
+
+    setUp(() {
+      _apiRepository = ApiRepository(localMode: false);
+    });
+
+    test('메시지 Json 테스트', () async {
+      ApiResult<MessagesResponseModel?> apiResult = await _apiRepository.getMessages(MessagesRequestModel());
+
+      expect(apiResult, isA<Success<MessagesResponseModel?>>());
+      expect((apiResult as Success<MessagesResponseModel?>).data != null, true);
+      expect((apiResult).data!.messages.isNotEmpty, true);
+    });
+
+    test('회의실 Json 테스트', () async {
+      ApiResult<RoomsResponseModel?> apiResult = await _apiRepository.getRooms(RoomsRequestModel());
+
+      expect(apiResult, isA<Success<RoomsResponseModel?>>());
+      expect((apiResult as Success<RoomsResponseModel?>).data != null, true);
+      expect((apiResult).data!.chatRooms.isNotEmpty, true);
+    });
+
+    test('유저목록 Json 테스트', () async {
+      ApiResult<UsersResponseModel?> apiResult = await _apiRepository.getUsers(UsersRequestModel());
+
+      expect(apiResult, isA<Success<UsersResponseModel?>>());
+      expect((apiResult as Success<UsersResponseModel?>).data != null, true);
+      expect((apiResult).data!.users.isNotEmpty, true);
+    });
+  });
+}

--- a/test/widget_test.dart
+++ b/test/widget_test.dart
@@ -5,26 +5,18 @@
 // gestures. You can also use WidgetTester to find child widgets in the widget
 // tree, read text, and verify that the values of widget properties are correct.
 
-import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
 
 import 'package:mobile1_flutter_coding_test/main.dart';
 
 void main() {
-  testWidgets('Counter increments smoke test', (WidgetTester tester) async {
-    // Build our app and trigger a frame.
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  testWidgets('앱 실행 후 화면 표시 확인', (WidgetTester tester) async {
     await tester.pumpWidget(const MyApp());
+    await tester.pumpAndSettle(const Duration(seconds: 2)); // 비동기 settle
 
-    // Verify that our counter starts at 0.
-    expect(find.text('0'), findsOneWidget);
-    expect(find.text('1'), findsNothing);
-
-    // Tap the '+' icon and trigger a frame.
-    await tester.tap(find.byIcon(Icons.add));
-    await tester.pump();
-
-    // Verify that our counter has incremented.
-    expect(find.text('0'), findsNothing);
-    expect(find.text('1'), findsOneWidget);
+    expect(find.text('사용자'), findsWidgets);
+    expect(find.text('회의실'), findsWidgets);
   });
 }


### PR DESCRIPTION
## 동작영상 및 스크린샷
 - 다운로드 URL: https://www.dropbox.com/scl/fo/uvsosu815jr4ubo0y3n05/AOGojCHnrIeYLkzN_WVfqk4?rlkey=nuq019mvwagayuhdrqkdbt04w&st=zaifu5n5&dl=0

 - 동작영상
  - videos/demo.mp4
 - 스크린샷: 
  - screenshots/chat_room.jpg
  - screenshots/chat_room_after_input.jpg
  - screenshots/chat_room_input_jpg
  - screenshots/chat_room_users_list.jpg
  - screenshots/rooms_list.jpg
  - screenshots/user_detail_1.jpg
  - screenshots/user_detail_2.jpg
  - screenshots/users_list.jpg

## 개발 환경:
  - Windows 11 Home 24H2 (26100.4946)
  - Android Studio Narwhal Feature Drop | 2025.1.2 Patch 1
  - Flutter 3.35.2
  - Dart SDK 3.9.0
  - SM F711N (Galaxy Z Flip3 5G)
  
## Flutter 라이브러리
 - cupertino_icons: 1.0.8
 - json_serializable: 6.11.0
 - json_annotation: 4.9.0
 - get: 4.7.2
 - get_storage: 2.1.1
 - dio: 5.9.0
 - retrofit: 4.7.2
 - sqflite: 2.4.2
 - cached_network_image: 3.4.1
 - intl: 0.20.2
 - bubble: 1.2.1
 - flutter_lints: 6.0.0
 - build_runner: 2.7.0
 - retrofit_generator: 10.0.2

## 중점 구현 사항
 - 서버 통신 시, Rest API를 호출하는 상황을 가정하여 Request/Response 모듈화
 - 서버 통신/로컬 Json 파일 열기는 내부 상수를 통해 스위칭 가능
 - 중복되는 위젯 공통화

## 스토리 구현 사항
 - 앱 실행 시: 사용자 목록 화면 표시
 - 화면 하단 탭: 사용자 목록 화면, 회의 목록 화면 이동 가능
 - 사용자 탭: 제공된 사용자 목록 외에 '나'를 추가함. 사용자를 클릭해 사용자 세부정보 확인 가능
 - 회의실(목록) 탭: 회의실 목록 표시. '마지막 메시지' 일시 순으로 내림차순 정렬됨.
 - 회의실(대화방) 화면: 대화 내용 표시 및 대화 입력 가능. 사용자의 썸네일을 클릭하면 사용자 세부정보 확인 가능. 입력한 대화내용은 DB에 저장되고, 회의실 목록 탭의 '마지막 메시지'에도 반영됨. 화면 우측 상단 햄버거 버튼을 누르면 참여자 목록이 표시되고, 사용자를 클릭해 사용자 세부정보 확인 가능.
 
## 이슈 및 개선이 필요한 사항: 
 - 사용자 세부정보 화면: 반응형으로 대응하기
 - 화면 하단 탭 및 회의실 목록 뱃지 추가하기 (GetStorage 사용)
 